### PR TITLE
Bump Version to `0.3.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bdew_datetimes
-version = 0.2.0
+version = 0.3.0
 description = Generate and work with holidays of the BDEW-Calendar for power and gas in Germany.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This is required because the Publish Action on `v.0.3.0` [failed](https://github.com/mj0nez/bdew-datetimes/actions/runs/4057346550):
> ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/          
         File already exists. See https://test.pypi.org/help/#file-name-reuse   
         for more information.