### PR TITLE
🖊Fix package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The implementation considers the publications of the **BDEW** (Bundesverband der
 
 Install the package from [pypi](https://pypi.org/project/bdew-datetimes/):
 ```bash
-pip install bdew_datetimes
+pip install bdew-datetimes
 ```
 
 ### Check if a date is a _specific_ BDEW Holidays


### PR DESCRIPTION
the package name is `bdew-datetimes`, not `bdew_datetimes` although the imports are:
```python
from bdew_datetimes import ...
```
and _not_
```python
from bdew-datetimes import ...
```