### PR TITLE
Fix Copy Paste Error in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 python_requires = >=3.7
 
 [options.package_data]
-holidays = py.typed
+bdew-datetimes = py.typed
 
 
 [flake8]


### PR DESCRIPTION
Fixes #32

To verfiy, that this fixes the error run
```bash
python setup.py build
```
and verify that the build directory contains the py.typed file.
