### PR TITLE
Remove `__version__` from `__init__.py`

### DIFF
--- a/src/bdew_datetimes/__init__.py
+++ b/src/bdew_datetimes/__init__.py
@@ -6,5 +6,3 @@ from pytz import timezone
 from .calendar import create_bdew_calendar
 
 GERMAN_TIME_ZONE = timezone("Europe/Berlin")
-
-__version__ = "0.3.5"


### PR DESCRIPTION
because the version is read from source control (tag)