### PR TITLE
Drop Support for Python 3.7

### DIFF
--- a/.github/workflows/packaging_test.yml
+++ b/.github/workflows/packaging_test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
because it reached end of life
