### PR TITLE
Synchronize `dev_requirements`: `typing-extensions`

### DIFF
--- a/dev_requirements/requirements-type_check.txt
+++ b/dev_requirements/requirements-type_check.txt
@@ -12,5 +12,5 @@ types-python-dateutil==2.9.0.20240316
     # via -r dev_requirements/requirements-type_check.in
 types-pytz==2024.1.0.20240417
     # via -r dev_requirements/requirements-type_check.in
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via mypy


### PR DESCRIPTION
Fixes
The conflict is caused by:
    The user requested typing-extensions==4.12.2
    The user requested typing-extensions==4.9.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
