### PR TITLE
fix: shift Sonderfeiertag for 24h LFW from `2025-04-04` to `2025-06-06`

### DIFF
--- a/src/bdew_datetimes/calendar.py
+++ b/src/bdew_datetimes/calendar.py
@@ -7,7 +7,7 @@ from datetime import date
 from typing import Any
 
 from holidays import HolidayBase, HolidaySum
-from holidays.constants import APR, DEC  # type:ignore[attr-defined]
+from holidays.constants import DEC, JUN  # type:ignore[attr-defined]
 from holidays.countries.germany import Germany
 
 
@@ -29,8 +29,9 @@ class BdewDefinedHolidays(HolidayBase):
         self[date(year, DEC, 24)] = "Heiligabend"
         self[date(year, DEC, 31)] = "Silvester"
         if year == 2025:
-            self[date(2025, APR, 4)] = (
-                "Sonderfeiertag"  # Anlässlich der Einführung des 24h Lieferantenwechsels
+            self[date(2025, JUN, 6)] = (
+                "Sonderfeiertag"
+                # Anlässlich der (verschobenen) Einführung des 24h Lieferantenwechsels
             )
 
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -30,7 +30,7 @@ def test_bdew_holidays(expected_holiday: date) -> None:
         pytest.param(date(2024, 8, 15), True, id="Mariä Himmelfahrt (BY, SL)"),
         pytest.param(date(2024, 11, 20), True, id="Buß- und Bettag (SN)"),
         pytest.param(date(2024, 12, 31), True, id="Silvester 2024 (BDEW)"),
-        pytest.param(date(2025, 4, 4), True, id="Sonderfeiertag 2025 (BDEW)"),
+        pytest.param(date(2025, 6, 6), True, id="Sonderfeiertag 2025 (BDEW)"),
     ],
 )
 def test_create_bdew_calendar(


### PR DESCRIPTION
according to BK6-24-174:
https://www.bundesnetzagentur.de/DE/Beschlusskammern/1_GZ/BK6-GZ/2022/BK6-22-024/Mitteilung_Nr_04/Mitteilung_Nr_04.html?nn=660086

> Für die operative Umsetzung bedeutet dies, dass alle bislang für ein Inkrafttreten zum 04.04.2025 vorgesehenen Umsetzungsinhalte stattdessen zum 06.06.2025 einzuführen sind. Zum Zweck der entsprechenden Anpassung aller erforderlichen Einführungsdokumente wird sich die Beschlusskammer mit dem BDEW in Verbindung setzen.

fixes https://github.com/mj0nez/bdew-datetimes/issues/191
