### PR TITLE
ci: verify commit signature of dependabot

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -13,6 +13,10 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Verify commit signature.
+        run: |
+          curl -s https://github.com/web-flow.gpg | gpg --import
+          git verify commit "$GITHUB_SHA"
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -13,10 +13,14 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - uses: actions/checkout@v4
       - name: Verify commit signature.
         run: |
           curl -s https://github.com/web-flow.gpg | gpg --import
-          git verify commit "$GITHUB_SHA"
+          echo "Imported GitHub keys."
+          
+          echo "Verifying signature of commit: $GITHUB_SHA"
+          git verify-commit "$GITHUB_SHA"
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
In light of the recent supply chain attack on a popular gh-action ([context](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)), I think we should be cautious with auto-approvals. 
cc: @hf-kklein